### PR TITLE
Autocomplete from Browser disable

### DIFF
--- a/cszcms/views/admin/login.php
+++ b/cszcms/views/admin/login.php
@@ -48,7 +48,8 @@
                         'class' => 'form-control',
                         'required' => 'required',
                         'value' => set_value('password'),
-                        'placeholder' => $this->lang->line('login_password')
+                        'placeholder' => $this->lang->line('login_password'),
+                        'autocomplete' => 'off' 
                     );
                     echo form_password($data);
                     ?>


### PR DESCRIPTION
For security reasons it is preferable that the password is not autocomplete from the browser so it is disabled.